### PR TITLE
make RtpPacket::SharedPtr

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/modules/pacing/paced_sender.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/pacing/paced_sender.cc
@@ -190,7 +190,7 @@ void PacedSender::Process() {
 
   size_t bytes_sent = 0;
   // MS_NOTE: Let's not use a useless vector.
-  RTC::RtpPacket* padding_packet{ nullptr };
+  RTC::RtpPacket::SharedPtr padding_packet{ nullptr };
 
   // Check if we should send padding.
   while (true)
@@ -212,7 +212,7 @@ void PacedSender::Process() {
     // TODO: REMOVE.
     // MS_DEBUG_DEV("sending padding packet [size:%zu]", padding_packet->GetSize());
 
-    packet_router_->SendPacket(padding_packet, pacing_info);
+    packet_router_->SendPacket(padding_packet.get(), pacing_info);
     bytes_sent += padding_packet->GetSize();
 
     if (recommended_probe_size && bytes_sent > *recommended_probe_size)

--- a/worker/deps/libwebrtc/libwebrtc/modules/pacing/packet_router.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/pacing/packet_router.h
@@ -35,7 +35,7 @@ class PacketRouter {
                           const PacedPacketInfo& cluster_info) = 0;
 
   // MS_NOTE: Changed to return a single RtpPacket pointer (maybe nullptr).
-  virtual RTC::RtpPacket* GeneratePadding(size_t target_size_bytes) = 0;
+  virtual RTC::RtpPacket::SharedPtr GeneratePadding(size_t target_size_bytes) = 0;
 };
 }  // namespace webrtc
 #endif  // MODULES_PACING_PACKET_ROUTER_H_

--- a/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
@@ -28,7 +28,7 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 
 	std::memcpy(data2, data, len);
 
-	::RTC::RtpPacket* packet = ::RTC::RtpPacket::Parse(data2, len);
+	auto packet = ::RTC::RtpPacket::Parse(data2, len);
 
 	if (!packet)
 		return;
@@ -179,9 +179,7 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->GetPayloadPadding();
 	packet->IsKeyFrame();
 
-	auto* clonedPacket = packet->Clone();
-
-	clonedPacket->DecRefCount();
+	auto clonedPacket = packet->Clone();
 
 	// TODO: packet->RtxEncode(); // This cannot be tested this way.
 	// TODO: packet->RtxDecode(); // This cannot be tested this way.
@@ -189,6 +187,4 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	// TODO: packet->ProcessPayload();
 	// TODO: packet->ProcessPayload();
 	// TODO: packet->ShiftPayload();
-
-	packet->DecRefCount();
 }

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -138,12 +138,12 @@ namespace RTC
 		{
 			this->externallyManagedBitrate = true;
 		}
-		virtual uint8_t GetBitratePriority() const                                        = 0;
-		virtual uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss)               = 0;
-		virtual void ApplyLayers()                                                        = 0;
-		virtual uint32_t GetDesiredBitrate() const                                        = 0;
-		virtual void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket) = 0;
-		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const             = 0;
+		virtual uint8_t GetBitratePriority() const                                                  = 0;
+		virtual uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss)                         = 0;
+		virtual void ApplyLayers()                                                                  = 0;
+		virtual uint32_t GetDesiredBitrate() const                                                  = 0;
+		virtual void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) = 0;
+		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const                       = 0;
 		virtual RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(
 		  RTC::RtpStreamSend* rtpStream, uint64_t nowMs) = 0;
 		virtual void NeedWorstRemoteFractionLost(uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) = 0;

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -30,7 +30,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/include/RTC/RtpProbationGenerator.hpp
+++ b/worker/include/RTC/RtpProbationGenerator.hpp
@@ -18,12 +18,12 @@ namespace RTC
 		virtual ~RtpProbationGenerator();
 
 	public:
-		RTC::RtpPacket* GetNextPacket(size_t size);
+		RTC::RtpPacket::SharedPtr GetNextPacket(size_t size);
 
 	private:
 		// Allocated by this.
 		uint8_t* probationPacketBuffer{ nullptr };
-		RTC::RtpPacket* probationPacket{ nullptr };
+		RTC::RtpPacket::SharedPtr probationPacket{ nullptr };
 	}; // namespace RTC
 
 } // namespace RTC

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -21,13 +21,13 @@ namespace RTC
 		struct StorageItem
 		{
 			// Original packet.
-			RTC::RtpPacket* originalPacket{ nullptr };
+			RTC::RtpPacket::SharedPtr originalPacket{ nullptr };
 			// Correct SSRC since original packet will have original ssrc.
 			uint32_t ssrc{ 0 };
 			// Correct sequence number since original packet will have original sequence number.
 			uint16_t sequenceNumber{ 0 };
 			// Cloned packet.
-			RTC::RtpPacket* clonedPacket{ nullptr };
+			RTC::RtpPacket::SharedPtr clonedPacket{ nullptr };
 			// Last time this packet was resent.
 			uint64_t resentAtMs{ 0u };
 			// Number of times this packet was resent.
@@ -65,7 +65,7 @@ namespace RTC
 
 		void FillJsonStats(json& jsonObject) override;
 		void SetRtx(uint8_t payloadType, uint32_t ssrc) override;
-		bool ReceivePacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket);
+		bool ReceivePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket);
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket);
 		void ReceiveKeyFrameRequest(RTC::RTCP::FeedbackPs::MessageType messageType);
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
@@ -82,7 +82,7 @@ namespace RTC
 		uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override;
 
 	private:
-		void StorePacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket);
+		void StorePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket);
 		void ClearBuffer();
 		void FillRetransmissionContainer(uint16_t seq, uint16_t bitmask);
 		void UpdateScore(RTC::RTCP::ReceiverReport* report);

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -40,7 +40,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -56,7 +56,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -51,7 +51,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -94,7 +94,7 @@ namespace RTC
 		/* Pure virtual methods inherited from webrtc::PacketRouter. */
 	public:
 		void SendPacket(RTC::RtpPacket* packet, const webrtc::PacedPacketInfo& pacingInfo) override;
-		RTC::RtpPacket* GeneratePadding(size_t size) override;
+		RTC::RtpPacket::SharedPtr GeneratePadding(size_t size) override;
 
 		/* Pure virtual methods inherited from RTC::Timer. */
 	public:

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -102,7 +102,7 @@ namespace RTC
 					return;
 				}
 
-				RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, len);
+				auto packet = RTC::RtpPacket::Parse(data, len);
 
 				if (!packet)
 				{
@@ -112,9 +112,7 @@ namespace RTC
 				}
 
 				// Pass the packet to the parent transport.
-				RTC::Transport::ReceiveRtpPacket(packet);
-
-				packet->DecRefCount();
+				RTC::Transport::ReceiveRtpPacket(packet.get());
 
 				break;
 			}

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -184,7 +184,7 @@ namespace RTC
 		return 0u;
 	}
 
-	void PipeConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket)
+	void PipeConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -594,7 +594,7 @@ namespace RTC
 
 		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &intLen))
 		{
-			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
+			auto packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 			if (!packet)
 			{
@@ -608,14 +608,12 @@ namespace RTC
 				  packet->GetSsrc(),
 				  packet->GetPayloadType(),
 				  packet->GetSequenceNumber());
-
-				packet->DecRefCount();
 			}
 
 			return;
 		}
 
-		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
+		auto packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{
@@ -632,15 +630,11 @@ namespace RTC
 			// Remove this SSRC.
 			RecvStreamClosed(packet->GetSsrc());
 
-			packet->DecRefCount();
-
 			return;
 		}
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet);
-
-		packet->DecRefCount();
+		RTC::Transport::ReceiveRtpPacket(packet.get());
 	}
 
 	inline void PipeTransport::OnRtcpDataReceived(

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -786,7 +786,7 @@ namespace RTC
 
 		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &intLen))
 		{
-			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
+			auto packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 			if (!packet)
 			{
@@ -800,14 +800,12 @@ namespace RTC
 				  packet->GetSsrc(),
 				  packet->GetPayloadType(),
 				  packet->GetSequenceNumber());
-
-				packet->DecRefCount();
 			}
 
 			return;
 		}
 
-		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
+		auto packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{
@@ -825,8 +823,6 @@ namespace RTC
 
 				// Remove this SSRC.
 				RecvStreamClosed(packet->GetSsrc());
-
-				packet->DecRefCount();
 
 				return;
 			}
@@ -862,15 +858,11 @@ namespace RTC
 			// Remove this SSRC.
 			RecvStreamClosed(packet->GetSsrc());
 
-			packet->DecRefCount();
-
 			return;
 		}
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet);
-
-		packet->DecRefCount();
+		RTC::Transport::ReceiveRtpPacket(packet.get());
 	}
 
 	inline void PlainTransport::OnRtcpDataReceived(

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -700,7 +700,7 @@ namespace RTC
 			// Cloned ref-counted packet that consumers will all store for as long as needed
 			// while also avoiding multiple allocations unless absolutely necessary.
 			// Clone only happens if needed though.
-			RtpPacket* clonedPacket{ nullptr };
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
 
 			for (auto* consumer : consumers)
 			{

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -15,7 +15,7 @@ namespace RTC
 
 	/* Class methods. */
 
-	RtpPacket* RtpPacket::Parse(const uint8_t* data, size_t len)
+	RtpPacket::SharedPtr RtpPacket::Parse(const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
 
@@ -124,7 +124,7 @@ namespace RTC
 		auto* packet = RtpPacketPool.Allocate();
 		new (packet) RtpPacket(header, headerExtension, payload, payloadLength, payloadPadding, len);
 
-		return packet;
+		return SharedPtr(packet);
 	}
 
 	/* Instance methods. */
@@ -150,9 +150,6 @@ namespace RTC
 
 	void RtpPacket::IncRefCount()
 	{
-		MS_ASSERT(
-		  this->buffer != nullptr, "Can only increase reference count for packets that own their memory");
-
 		MS_ASSERT(
 		  this->referenceCount > 0, "Can only increase reference count for packets that are still alive");
 
@@ -673,7 +670,7 @@ namespace RTC
 		SetPayloadPaddingFlag(false);
 	}
 
-	RtpPacket* RtpPacket::Clone() const
+	RtpPacket::SharedPtr RtpPacket::Clone() const
 	{
 		MS_TRACE();
 
@@ -753,7 +750,7 @@ namespace RTC
 		// Store allocated buffer.
 		packet->buffer = buffer;
 
-		return packet;
+		return SharedPtr(packet);
 	}
 
 	// NOTE: The caller must ensure that the buffer/memmory of the packet has

--- a/worker/src/RTC/RtpProbationGenerator.cpp
+++ b/worker/src/RTC/RtpProbationGenerator.cpp
@@ -130,10 +130,10 @@ namespace RTC
 		delete[] this->probationPacketBuffer;
 
 		// Release the probation RTP packet.
-		this->probationPacket->DecRefCount();
+		this->probationPacket.reset();
 	}
 
-	RTC::RtpPacket* RtpProbationGenerator::GetNextPacket(size_t size)
+	RTC::RtpPacket::SharedPtr RtpProbationGenerator::GetNextPacket(size_t size)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -228,7 +228,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SimpleConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket)
+	void SimpleConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -640,7 +640,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SimulcastConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket)
+	void SimulcastConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -532,7 +532,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SvcConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket** clonedPacket)
+	void SvcConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -414,7 +414,7 @@ namespace RTC
 		this->listener->OnTransportCongestionControlClientSendRtpPacket(this, packet, pacingInfo);
 	}
 
-	RTC::RtpPacket* TransportCongestionControlClient::GeneratePadding(size_t size)
+	RTC::RtpPacket::SharedPtr TransportCongestionControlClient::GeneratePadding(size_t size)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -994,7 +994,7 @@ namespace RTC
 
 		if (!this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &intLen))
 		{
-			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
+			auto packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 			if (!packet)
 			{
@@ -1008,14 +1008,12 @@ namespace RTC
 				  packet->GetSsrc(),
 				  packet->GetPayloadType(),
 				  packet->GetSequenceNumber());
-
-				packet->DecRefCount();
 			}
 
 			return;
 		}
 
-		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
+		auto packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{
@@ -1028,9 +1026,7 @@ namespace RTC
 		this->iceServer->ForceSelectedTuple(tuple);
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet);
-
-		packet->DecRefCount();
+		RTC::Transport::ReceiveRtpPacket(packet.get());
 	}
 
 	inline void WebRtcTransport::OnRtcpDataReceived(

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -116,7 +116,7 @@ uint8_t rtpBuffer[] =
 // clang-format on
 
 // [pt:123, seq:21006, timestamp:1533790901]
-RtpPacket* packet = RtpPacket::Parse(rtpBuffer, sizeof(rtpBuffer));
+auto packet = RtpPacket::Parse(rtpBuffer, sizeof(rtpBuffer));
 
 void validate(std::vector<TestNackGeneratorInput>& inputs)
 {
@@ -131,7 +131,7 @@ void validate(std::vector<TestNackGeneratorInput>& inputs)
 
 		packet->SetPayloadDescriptorHandler(tpdh);
 		packet->SetSequenceNumber(input.seq);
-		nackGenerator.ReceivePacket(packet, /*isRecovered*/ false);
+		nackGenerator.ReceivePacket(packet.get(), /*isRecovered*/ false);
 
 		listener.Check(nackGenerator);
 	}

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -22,7 +22,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		if (!helpers::readBinaryFile("data/packet1.raw", buffer, &len))
 			FAIL("cannot open file");
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		auto packet = RtpPacket::Parse(buffer, len);
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -46,8 +46,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(extenValue == nullptr);
 		REQUIRE(packet->ReadRid(rid) == false);
 		REQUIRE(rid == "");
-
-		packet->DecRefCount();
 	}
 
 	SECTION("parse packet2.raw")
@@ -57,7 +55,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		if (!helpers::readBinaryFile("data/packet2.raw", buffer, &len))
 			FAIL("cannot open file");
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		auto packet = RtpPacket::Parse(buffer, len);
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -72,8 +70,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetHeaderExtensionLength() == 0);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
-
-		packet->DecRefCount();
 	}
 
 	SECTION("parse packet3.raw")
@@ -88,7 +84,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		if (!helpers::readBinaryFile("data/packet3.raw", buffer, &len))
 			FAIL("cannot open file");
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		auto packet = RtpPacket::Parse(buffer, len);
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -127,7 +123,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->ReadAbsSendTime(absSendTime) == true);
 		REQUIRE(absSendTime == 0x65341e);
 
-		auto* clonedPacket = packet->Clone();
+		auto clonedPacket = packet->Clone();
 
 		std::memset(buffer, '0', sizeof(buffer));
 
@@ -162,9 +158,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(extenValue[2] == 0x1e);
 		REQUIRE(clonedPacket->ReadAbsSendTime(absSendTime) == true);
 		REQUIRE(absSendTime == 0x65341e);
-
-		packet->DecRefCount();
-		clonedPacket->DecRefCount();
 	}
 
 	SECTION("create RtpPacket without header extension")
@@ -178,7 +171,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		auto packet = RtpPacket::Parse(buffer, sizeof(buffer));
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -191,8 +184,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetSsrc() == 5);
-
-		packet->DecRefCount();
 	}
 
 	SECTION("create RtpPacket with One-Byte header extension")
@@ -210,7 +201,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		auto packet = RtpPacket::Parse(buffer, sizeof(buffer));
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -232,8 +223,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		REQUIRE(packet->GetPayloadLength() == 1000);
 		REQUIRE(packet->GetSize() == 1028);
-
-		packet->DecRefCount();
 	}
 
 	SECTION("create RtpPacket with Two-Bytes header extension")
@@ -255,7 +244,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		uint8_t extenLen;
 		uint8_t* extenValue;
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		auto packet = RtpPacket::Parse(buffer, sizeof(buffer));
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -298,8 +287,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasExtension(5) == false);
 		REQUIRE(extenValue == nullptr);
 		REQUIRE(extenLen == 0);
-
-		packet->DecRefCount();
 	}
 
 	SECTION("rtx encryption-decryption")
@@ -322,7 +309,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		uint32_t rtxSsrc{ 6 };
 		uint16_t rtxSeq{ 80 };
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		auto packet = RtpPacket::Parse(buffer, sizeof(buffer));
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -339,8 +326,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions());
 
 		auto rtxPacket = packet->Clone();
-
-		packet->DecRefCount();
 
 		std::memset(buffer, '0', sizeof(buffer));
 
@@ -369,8 +354,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(rtxPacket->GetHeaderExtensionLength() == 12);
 		REQUIRE(rtxPacket->HasOneByteExtensions() == false);
 		REQUIRE(rtxPacket->HasTwoBytesExtensions());
-
-		rtxPacket->DecRefCount();
 	}
 
 	SECTION("create RtpPacket and apply payload shift to it")
@@ -395,8 +378,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		size_t len        = 40;
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		size_t len  = 40;
+		auto packet = RtpPacket::Parse(buffer, len);
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -480,8 +463,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetPayloadLength() == 1000);
 		REQUIRE(packet->GetPayloadPadding() == 0);
 		REQUIRE(packet->GetSize() == 1028);
-
-		packet->DecRefCount();
 	}
 
 	SECTION("set One-Byte header extensions")
@@ -505,7 +486,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, 28);
+		auto packet = RtpPacket::Parse(buffer, 28);
 		std::vector<RTC::RtpPacket::GenericExtension> extensions;
 		uint8_t extenLen;
 		uint8_t* extenValue;
@@ -644,8 +625,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(extenValue[1] == 0x02);
 		REQUIRE(extenValue[2] == 0x03);
 		REQUIRE(extenValue[3] == 0x00);
-
-		packet->DecRefCount();
 	}
 
 	SECTION("set Two-Bytes header extensions")
@@ -668,7 +647,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, 28);
+		auto packet = RtpPacket::Parse(buffer, 28);
 		std::vector<RTC::RtpPacket::GenericExtension> extensions;
 		uint8_t extenLen;
 		uint8_t* extenValue;
@@ -789,8 +768,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetExtension(24, extenLen));
 		REQUIRE(packet->HasExtension(24) == true);
 		REQUIRE(extenLen == 4);
-
-		packet->DecRefCount();
 	}
 
 	SECTION("read frame-marking extension")
@@ -807,7 +784,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		auto packet = RtpPacket::Parse(buffer, sizeof(buffer));
 
 		if (!packet)
 			FAIL("not a RTP packet");
@@ -839,7 +816,5 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(frameMarking->tid == 3);
 		REQUIRE(frameMarking->lid == 1);
 		REQUIRE(frameMarking->tl0picidx == 5);
-
-		packet->DecRefCount();
 	}
 }

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -40,14 +40,14 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		// clang-format on
 
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		RtpPacket* packet1 = RtpPacket::Parse(rtpBuffer1, sizeof(rtpBuffer1));
+		auto packet1 = RtpPacket::Parse(rtpBuffer1, sizeof(rtpBuffer1));
 
 		REQUIRE(packet1);
 		REQUIRE(packet1->GetSequenceNumber() == 21006);
 		REQUIRE(packet1->GetTimestamp() == 1533790901);
 
 		// packet2 [pt:123, seq:21007, timestamp:1533791173]
-		RtpPacket* packet2 = packet1->Clone();
+		auto packet2 = packet1->Clone();
 
 		packet2->SetSequenceNumber(21007);
 		packet2->SetTimestamp(1533791173);
@@ -56,7 +56,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		REQUIRE(packet2->GetTimestamp() == 1533791173);
 
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
-		RtpPacket* packet3 = packet1->Clone();
+		auto packet3 = packet1->Clone();
 
 		packet3->SetSequenceNumber(21008);
 		packet3->SetTimestamp(1533793871);
@@ -65,7 +65,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		REQUIRE(packet3->GetTimestamp() == 1533793871);
 
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
-		RtpPacket* packet4 = packet1->Clone();
+		auto packet4 = packet1->Clone();
 
 		packet4->SetSequenceNumber(21009);
 		packet4->SetTimestamp(1533793871);
@@ -74,7 +74,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		REQUIRE(packet4->GetTimestamp() == 1533793871);
 
 		// packet5 [pt:123, seq:21010, timestamp:1533971078]
-		RtpPacket* packet5 = packet1->Clone();
+		auto packet5 = packet1->Clone();
 
 		packet5->SetSequenceNumber(21010);
 		packet5->SetTimestamp(1533971078);
@@ -94,36 +94,36 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 
 		// Receive all the packets (some of them not in order and/or duplicated).
 		{
-			RtpPacket* clonedPacket{ nullptr };
-			stream->ReceivePacket(packet1, &clonedPacket);
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
+			stream->ReceivePacket(packet1.get(), &clonedPacket);
 		}
 		{
-			RtpPacket* clonedPacket{ nullptr };
-			stream->ReceivePacket(packet3, &clonedPacket);
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
+			stream->ReceivePacket(packet3.get(), &clonedPacket);
 		}
 		{
-			RtpPacket* clonedPacket{ nullptr };
-			stream->ReceivePacket(packet2, &clonedPacket);
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
+			stream->ReceivePacket(packet2.get(), &clonedPacket);
 		}
 		{
-			RtpPacket* clonedPacket{ nullptr };
-			stream->ReceivePacket(packet3, &clonedPacket);
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
+			stream->ReceivePacket(packet3.get(), &clonedPacket);
 		}
 		{
-			RtpPacket* clonedPacket{ nullptr };
-			stream->ReceivePacket(packet4, &clonedPacket);
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
+			stream->ReceivePacket(packet4.get(), &clonedPacket);
 		}
 		{
-			RtpPacket* clonedPacket{ nullptr };
-			stream->ReceivePacket(packet4, &clonedPacket);
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
+			stream->ReceivePacket(packet4.get(), &clonedPacket);
 		}
 		{
-			RtpPacket* clonedPacket{ nullptr };
-			stream->ReceivePacket(packet5, &clonedPacket);
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
+			stream->ReceivePacket(packet5.get(), &clonedPacket);
 		}
 		{
-			RtpPacket* clonedPacket{ nullptr };
-			stream->ReceivePacket(packet5, &clonedPacket);
+			RtpPacket::SharedPtr clonedPacket{ nullptr };
+			stream->ReceivePacket(packet5.get(), &clonedPacket);
 		}
 
 		// Create a NACK item that request for all the packets.
@@ -162,12 +162,6 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		REQUIRE(rtxPacket4->GetSequenceNumber() == packet5->GetSequenceNumber());
 		REQUIRE(rtxPacket4->GetTimestamp() == packet5->GetTimestamp());
 
-		// Clean stuff.
-		packet1->DecRefCount();
-		packet2->DecRefCount();
-		packet3->DecRefCount();
-		packet4->DecRefCount();
-		packet5->DecRefCount();
 		delete stream;
 	}
 }


### PR DESCRIPTION
Create smartpointer class for RTC::RtpPacket. Because when using std::shared_ptr that need extra allocation cost for count and pointer area.