### PR TITLE
Rework retransmission buffer

### DIFF
--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -36,19 +36,8 @@ namespace RTC
 			bool rtxEncoded{ false };
 		};
 
-		class Bucket {
-		public:
-			static constexpr size_t BucketSize = 256;
-			StorageItem* Get(size_t pos) const;
-			void Insert(size_t pos, StorageItem* item);
-			void Remove(size_t pos);
-			void Clear();
-			bool IsEmpty() const;
-		private:
-			std::array<StorageItem*, BucketSize> buffer {};
-			size_t count { 0 };
-		};
-
+		static constexpr size_t BucketsCount = 256;
+		static constexpr size_t BucketSize = 256;
 	private:
 
 		// Special container that can store `StorageItem*` elements addressable by their `uint16_t`
@@ -56,7 +45,6 @@ namespace RTC
 		// minimum and maximum sequence number instead all 65536 potential elements.
 		class StorageItemBuffer
 		{
-			static constexpr size_t BucketsCount = 256;
 		public:
 			~StorageItemBuffer();
 
@@ -72,7 +60,7 @@ namespace RTC
 			static size_t GetPositionInBucket(uint16_t seq);
 
 			int32_t oldestSeq { -1 };
-			std::array<Bucket*, BucketsCount> buckets {};
+			std::array<Utils::Bucket<StorageItem, BucketSize>*, BucketsCount> buckets {};
 		};
 
 	public:

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -37,9 +37,9 @@ namespace RTC
 		};
 
 		static constexpr size_t BucketsCount = 256;
-		static constexpr size_t BucketSize = 256;
-	private:
+		static constexpr size_t BucketSize   = 256;
 
+	private:
 		// Special container that can store `StorageItem*` elements addressable by their `uint16_t`
 		// sequence number, while only taking as little memory as necessary to store the range between
 		// minimum and maximum sequence number instead all 65536 potential elements.
@@ -53,13 +53,14 @@ namespace RTC
 			bool Remove(uint16_t seq);
 			void Clear();
 			StorageItem* GetOldest() const;
+
 		private:
 			void InvalidateOldest(uint16_t prevOldest);
 			static size_t GetBucketIndex(uint16_t seq);
 			static size_t GetPositionInBucket(uint16_t seq);
 
-			int32_t oldestSeq { -1 };
-			std::array<Utils::Bucket<StorageItem, BucketSize>*, BucketsCount> buckets {};
+			int32_t oldestSeq{ -1 };
+			std::array<Utils::Bucket<StorageItem, BucketSize>*, BucketsCount> buckets{};
 		};
 
 	public:

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -54,7 +54,6 @@ namespace RTC
 			void Clear();
 			StorageItem* GetOldest() const;
 		private:
-			void TryUpdateOldest(uint16_t seq, StorageItem* storageItem);
 			void InvalidateOldest(uint16_t prevOldest);
 			static size_t GetBucketIndex(uint16_t seq);
 			static size_t GetPositionInBucket(uint16_t seq);

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -2,11 +2,13 @@
 #define MS_UTILS_HPP
 
 #include "common.hpp"
+#include "Logger.hpp"
 #include <openssl/hmac.h>
 #include <cmath>
 #include <cstring> // std::memcmp(), std::memcpy()
 #include <nlohmann/json.hpp>
 #include <string>
+#include <array>
 #ifdef _WIN32
 #include <ws2ipdef.h>
 // https://stackoverflow.com/a/24550632/2085408
@@ -387,6 +389,58 @@ namespace Utils
 
 	private:
 		std::vector<T*> pool;
+	};
+
+	template<typename T, std::size_t BucketSize>
+	class Bucket {
+	public:
+		T* Get(size_t pos) const
+		{
+			MS_ASSERT(pos < this->buffer.size() && pos >= 0, "Position out of range");
+			return this->buffer[pos];
+		}
+
+		void Insert(size_t pos, T* item)
+		{
+			MS_ASSERT(pos < this->buffer.size() && pos >= 0, "Position out of range");
+			MS_ASSERT(item != nullptr, "Item must be not null");
+			++this->count;
+			this->buffer[pos] = item;
+		}
+
+		T* Remove(size_t pos)
+		{
+			MS_ASSERT(pos < this->buffer.size() && pos >= 0, "Position out of range");
+
+			auto item = this->buffer[pos];
+
+			if (item)
+			{
+				--this->count;
+				this->buffer[pos] = nullptr;
+			}
+
+			return item;
+		}
+
+		bool IsEmpty() const
+		{
+			return this->count == 0;
+		}
+
+		size_t Count() const
+		{
+			return this->count;
+		}
+
+		size_t Size() const
+		{
+			return BucketSize;
+		}
+
+	private:
+		std::array<T*, BucketSize> buffer {};
+		size_t count { 0 };
 	};
 
 } // namespace Utils

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -4,11 +4,11 @@
 #include "common.hpp"
 #include "Logger.hpp"
 #include <openssl/hmac.h>
+#include <array>
 #include <cmath>
 #include <cstring> // std::memcmp(), std::memcpy()
 #include <nlohmann/json.hpp>
 #include <string>
-#include <array>
 #ifdef _WIN32
 #include <ws2ipdef.h>
 // https://stackoverflow.com/a/24550632/2085408
@@ -392,7 +392,8 @@ namespace Utils
 	};
 
 	template<typename T, std::size_t BucketSize>
-	class Bucket {
+	class Bucket
+	{
 	public:
 		T* Get(size_t pos) const
 		{
@@ -439,8 +440,8 @@ namespace Utils
 		}
 
 	private:
-		std::array<T*, BucketSize> buffer {};
-		size_t count { 0 };
+		std::array<T*, BucketSize> buffer{};
+		size_t count{ 0 };
 	};
 
 } // namespace Utils

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -484,7 +484,7 @@ namespace RTC
 
 			// Cleanup is finished if we found an item with recent enough packet, but also account
 			// for out-of-order packets.
-			if (diffMs < this->retransmissionBufferSize || packetTs < checkedPacketTs)
+			if (diffMs < this->retransmissionBufferSize || SeqManager<uint32_t>::IsSeqHigherThan(checkedPacketTs, packetTs))
 				break;
 
 			// Unfill the buffer start item.

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -149,7 +149,7 @@ namespace RTC
 			return;
 		}
 
-		if (oldest->originalPacket->GetTimestamp() > storageItem->originalPacket->GetTimestamp())
+		if (SeqManager<uint32_t>::IsSeqHigherThan(oldest->originalPacket->GetTimestamp(), storageItem->originalPacket->GetTimestamp()))
 		{
 			this->oldestSeq = seq;
 		}

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -11,7 +11,8 @@ namespace RTC
 	/* Static. */
 
 	thread_local static Utils::ObjectPool<RtpStreamSend::StorageItem> StorageItemPool;
-	thread_local static Utils::ObjectPool<Utils::Bucket<RtpStreamSend::StorageItem, RtpStreamSend::BucketSize>> StorageItemBucketPool;
+	thread_local static Utils::ObjectPool<Utils::Bucket<RtpStreamSend::StorageItem, RtpStreamSend::BucketSize>>
+	  StorageItemBucketPool;
 
 	// 17: 16 bit mask + the initial sequence number.
 	static constexpr size_t MaxRequestedPackets{ 17 };
@@ -52,7 +53,7 @@ namespace RTC
 
 	bool RtpStreamSend::StorageItemBuffer::Insert(uint16_t seq, StorageItem* storageItem)
 	{
-		auto bucketIdx = StorageItemBuffer::GetBucketIndex(seq);
+		auto bucketIdx   = StorageItemBuffer::GetBucketIndex(seq);
 		auto inBucketPos = StorageItemBuffer::GetPositionInBucket(seq);
 
 		if (!this->buckets[bucketIdx])
@@ -71,12 +72,8 @@ namespace RTC
 		{
 			this->oldestSeq = seq;
 		}
-		else if (
-			SeqManager<uint32_t>::IsSeqHigherThan(
-				oldest->originalPacket->GetTimestamp(),
-				storageItem->originalPacket->GetTimestamp()
-			)
-		)
+		else if (SeqManager<uint32_t>::IsSeqHigherThan(
+		           oldest->originalPacket->GetTimestamp(), storageItem->originalPacket->GetTimestamp()))
 		{
 			this->oldestSeq = seq;
 		}
@@ -86,7 +83,7 @@ namespace RTC
 
 	bool RtpStreamSend::StorageItemBuffer::Remove(uint16_t seq)
 	{
-		auto bucketIdx = StorageItemBuffer::GetBucketIndex(seq);
+		auto bucketIdx   = StorageItemBuffer::GetBucketIndex(seq);
 		auto inBucketPos = StorageItemBuffer::GetPositionInBucket(seq);
 
 		auto bucket = this->buckets[bucketIdx];
@@ -126,7 +123,7 @@ namespace RTC
 			if (!bucket)
 				continue;
 
-			for(size_t pos = 0; pos < bucket->Size() && !bucket->IsEmpty(); ++pos)
+			for (size_t pos = 0; pos < bucket->Size() && !bucket->IsEmpty(); ++pos)
 			{
 				auto item = bucket->Remove(pos);
 
@@ -156,11 +153,8 @@ namespace RTC
 
 	void RtpStreamSend::StorageItemBuffer::InvalidateOldest(uint16_t prevOldest)
 	{
-		for (
-			size_t candidateSeq = (prevOldest + 1) % (1 << 16);
-			candidateSeq != prevOldest;
-			candidateSeq = (candidateSeq + 1) % (1 << 16)
-		)
+		for (size_t candidateSeq = (prevOldest + 1) % (1 << 16); candidateSeq != prevOldest;
+		     candidateSeq        = (candidateSeq + 1) % (1 << 16))
 		{
 			auto bucketIdx = StorageItemBuffer::GetBucketIndex(candidateSeq);
 
@@ -495,7 +489,8 @@ namespace RTC
 
 			// Unfill the buffer start item.
 			MS_ASSERT(
-				this->storageItemBuffer.Remove(checkedStorageItem->sequenceNumber), "Storage item must be used");
+			  this->storageItemBuffer.Remove(checkedStorageItem->sequenceNumber),
+			  "Storage item must be used");
 		}
 
 		// Allocate a new storage item.

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -64,7 +64,22 @@ namespace RTC
 
 		this->buckets[bucketIdx]->Insert(inBucketPos, storageItem);
 
-		this->TryUpdateOldest(seq, storageItem);
+		// Try to update oldest packet sequence number
+		auto oldest = this->GetOldest();
+
+		if (!oldest)
+		{
+			this->oldestSeq = seq;
+		}
+		else if (
+			SeqManager<uint32_t>::IsSeqHigherThan(
+				oldest->originalPacket->GetTimestamp(),
+				storageItem->originalPacket->GetTimestamp()
+			)
+		)
+		{
+			this->oldestSeq = seq;
+		}
 
 		return true;
 	}
@@ -137,22 +152,6 @@ namespace RTC
 		}
 
 		return nullptr;
-	}
-
-	void RtpStreamSend::StorageItemBuffer::TryUpdateOldest(uint16_t seq, RtpStreamSend::StorageItem* storageItem)
-	{
-		auto oldest = this->GetOldest();
-
-		if (!oldest)
-		{
-			this->oldestSeq = seq;
-			return;
-		}
-
-		if (SeqManager<uint32_t>::IsSeqHigherThan(oldest->originalPacket->GetTimestamp(), storageItem->originalPacket->GetTimestamp()))
-		{
-			this->oldestSeq = seq;
-		}
 	}
 
 	void RtpStreamSend::StorageItemBuffer::InvalidateOldest(uint16_t prevOldest)


### PR DESCRIPTION
Main goals:
1. Fix memory leak of cloned RTP packets;
2. Reduce allocations in retransmission buffer