### PR TITLE
RtpPacket: use standard shared pointer

### DIFF
--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -142,7 +142,7 @@ namespace RTC
 		virtual uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss)                         = 0;
 		virtual void ApplyLayers()                                                                  = 0;
 		virtual uint32_t GetDesiredBitrate() const                                                  = 0;
-		virtual void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) = 0;
+		virtual void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) = 0;
 		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const                       = 0;
 		virtual RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(
 		  RTC::RtpStreamSend* rtpStream, uint64_t nowMs) = 0;

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -30,7 +30,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -23,7 +23,7 @@ namespace RTC
 	{
 	public:
 		using RtpPacketBuffer = std::array<uint8_t, MtuSize + 100>;
-		using SharedPtr = std::shared_ptr<RtpPacket>;
+		using SharedPtr       = std::shared_ptr<RtpPacket>;
 
 		/* Struct for RTP header. */
 		struct Header
@@ -609,7 +609,6 @@ namespace RTC
 		void ShiftPayload(size_t payloadOffset, size_t shift, bool expand = true);
 
 	private:
-
 		friend SharedPtr;
 
 		void ParseExtensions();

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -23,6 +23,7 @@ namespace RTC
 	{
 	public:
 		using RtpPacketBuffer = std::array<uint8_t, MtuSize + 100>;
+		using SharedPtr = std::shared_ptr<RtpPacket>;
 
 		/* Struct for RTP header. */
 		struct Header
@@ -131,89 +132,8 @@ namespace RTC
 			);
 			// clang-format on
 		}
-		class SharedPtr
-		{
-		public:
-			RtpPacket* get()
-			{
-				return this->ptr;
-			}
-			explicit SharedPtr(RtpPacket* ptr) : ptr(ptr)
-			{
-			}
-			explicit SharedPtr(std::nullptr_t aNullptr) : ptr(aNullptr)
-			{
-			}
-			SharedPtr(const SharedPtr& sharedPtr) : ptr(sharedPtr.ptr)
-			{
-				if (this->ptr)
-				{
-					this->ptr->IncRefCount();
-				}
-			}
-			SharedPtr(SharedPtr&& sharedPtr) noexcept : ptr(sharedPtr.ptr)
-			{
-				sharedPtr.ptr = nullptr;
-			}
-			SharedPtr& operator=(SharedPtr&& sharedPtr) noexcept
-			{
-				this->ptr     = sharedPtr.ptr;
-				sharedPtr.ptr = nullptr;
 
-				return *this;
-			}
-			SharedPtr& operator=(const SharedPtr& sharedPtr)
-			{
-				if (this == &sharedPtr)
-				{
-					return *this;
-				}
-
-				if (sharedPtr.ptr)
-				{
-					sharedPtr.ptr->IncRefCount();
-				}
-
-				if (this->ptr)
-				{
-					this->ptr->DecRefCount();
-				}
-
-				this->ptr = sharedPtr.ptr;
-
-				return *this;
-			}
-			~SharedPtr()
-			{
-				Reset();
-			}
-			explicit operator bool() const
-			{
-				return this->ptr;
-			}
-			void Reset()
-			{
-				if (this->ptr)
-				{
-					this->ptr->DecRefCount();
-				}
-
-				this->ptr = nullptr;
-			}
-			RtpPacket& operator*() const noexcept
-			{
-				return *this->ptr;
-			}
-			RtpPacket* operator->() const noexcept
-			{
-				return this->ptr;
-			}
-
-		private:
-			RtpPacket* ptr;
-		};
-
-		static RtpPacket::SharedPtr Parse(const uint8_t* data, size_t len);
+		static SharedPtr Parse(const uint8_t* data, size_t len);
 
 	private:
 		RtpPacket(
@@ -224,7 +144,6 @@ namespace RTC
 		  uint8_t payloadPadding,
 		  size_t size);
 
-		// Use `RtpPacket::DecRefCount()` instead
 		~RtpPacket();
 
 	public:
@@ -672,7 +591,7 @@ namespace RTC
 			return this->payloadDescriptorHandler->IsKeyFrame();
 		}
 
-		RtpPacket::SharedPtr Clone() const;
+		SharedPtr Clone() const;
 
 		void RtxEncode(uint8_t payloadType, uint32_t ssrc, uint16_t seq);
 
@@ -690,13 +609,8 @@ namespace RTC
 		void ShiftPayload(size_t payloadOffset, size_t shift, bool expand = true);
 
 	private:
-		friend class SharedPtr;
 
-		// Increase reference count for the packet.
-		void IncRefCount();
-
-		// Decrease reference count for the packet, packet will be removed when reference count reaches zero.
-		void DecRefCount();
+		friend SharedPtr;
 
 		void ParseExtensions();
 
@@ -728,7 +642,6 @@ namespace RTC
 		// Buffer where this packet is allocated, can be `nullptr` if packet was parsed from externally
 		// provided buffer.
 		RtpPacketBuffer* buffer{ nullptr };
-		size_t referenceCount{ 1 };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -45,7 +45,7 @@ namespace RTC
 		public:
 			~StorageItemBuffer();
 
-			StorageItem* Get(uint16_t seq);
+			StorageItem* Get(uint16_t seq) const;
 			bool Insert(uint16_t seq, StorageItem* storageItem);
 			bool Remove(uint16_t seq);
 			void Clear();

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -65,7 +65,7 @@ namespace RTC
 
 		void FillJsonStats(json& jsonObject) override;
 		void SetRtx(uint8_t payloadType, uint32_t ssrc) override;
-		bool ReceivePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket);
+		bool ReceivePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket);
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket);
 		void ReceiveKeyFrameRequest(RTC::RTCP::FeedbackPs::MessageType messageType);
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
@@ -82,7 +82,7 @@ namespace RTC
 		uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override;
 
 	private:
-		void StorePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket);
+		void StorePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket);
 		void ClearBuffer();
 		void FillRetransmissionContainer(uint16_t seq, uint16_t bitmask);
 		void UpdateScore(RTC::RTCP::ReceiverReport* report);

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -40,7 +40,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -56,7 +56,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -51,7 +51,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -184,7 +184,7 @@ namespace RTC
 		return 0u;
 	}
 
-	void PipeConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
+	void PipeConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -710,7 +710,7 @@ namespace RTC
 				if (!mid.empty())
 					packet->UpdateMid(mid);
 
-				consumer->SendRtpPacket(packet, &clonedPacket);
+				consumer->SendRtpPacket(packet, clonedPacket);
 			}
 		}
 

--- a/worker/src/RTC/RtpProbationGenerator.cpp
+++ b/worker/src/RTC/RtpProbationGenerator.cpp
@@ -130,7 +130,7 @@ namespace RTC
 		delete[] this->probationPacketBuffer;
 
 		// Release the probation RTP packet.
-		this->probationPacket.Reset();
+		this->probationPacket.reset();
 	}
 
 	RTC::RtpPacket::SharedPtr RtpProbationGenerator::GetNextPacket(size_t size)

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -29,8 +29,8 @@ namespace RTC
 
 		MS_ASSERT(storageItem, "storageItem cannot be nullptr");
 
-		storageItem->clonedPacket.Reset();
-		storageItem->originalPacket.Reset();
+		storageItem->clonedPacket.reset();
+		storageItem->originalPacket.reset();
 		storageItem->resentAtMs = 0;
 		storageItem->sentTimes  = 0;
 		storageItem->rtxEncoded = false;
@@ -421,9 +421,9 @@ namespace RTC
 		{
 			// Allocate a new storage item.
 			storageItem = StorageItemPool.Allocate();
-			// Memory is not initialized in any way, initialize with default values it to make sure
-			// contents is correct.
-			*storageItem = StorageItem{};
+
+			// Memory is not initialized in any way, reset it.
+			std::memset(storageItem, 0, sizeof(StorageItem));
 			MS_ASSERT(this->storageItemBuffer.Insert(seq, storageItem), "sequence number must be empty");
 
 			// Set the beginning of the used buffer.

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -400,7 +400,6 @@ namespace RTC
 	{
 		MS_TRACE();
 
-
 		if (packet->GetSize() > RTC::MtuSize)
 		{
 			MS_WARN_TAG(

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -421,9 +421,9 @@ namespace RTC
 		{
 			// Allocate a new storage item.
 			storageItem = StorageItemPool.Allocate();
-
-			// Memory is not initialized in any way, reset it.
-			std::memset(storageItem, 0, sizeof(StorageItem));
+			// Memory is not initialized in any way, reset it. Create a new StorageItem instance
+			// in this memory.
+			new (storageItem) StorageItem{};
 			MS_ASSERT(this->storageItemBuffer.Insert(seq, storageItem), "sequence number must be empty");
 
 			// Set the beginning of the used buffer.

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -36,7 +36,7 @@ namespace RTC
 		storageItem->rtxEncoded = false;
 	}
 
-	RtpStreamSend::StorageItem* RtpStreamSend::StorageItemBuffer::Get(uint16_t seq)
+	RtpStreamSend::StorageItem* RtpStreamSend::StorageItemBuffer::Get(uint16_t seq) const
 	{
 		auto idx{ static_cast<uint16_t>(seq - this->startSeq) };
 
@@ -389,6 +389,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
+
 		if (packet->GetSize() > RTC::MtuSize)
 		{
 			MS_WARN_TAG(
@@ -485,7 +486,10 @@ namespace RTC
 		// Only clone once and only if necessary.
 		if (!clonedPacket.get())
 		{
-			clonedPacket = packet->Clone();
+			auto clone = packet->Clone();
+
+			// Move the RtpPacket pointer into clonedPacket shared pointer.
+			clonedPacket.swap(clone);
 		}
 
 		// Store original packet and some extra info into the retrieved storage item.

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -185,7 +185,7 @@ namespace RTC
 		this->rtxSeq = Utils::Crypto::GetRandomUInt(0u, 0xFFFF);
 	}
 
-	bool RtpStreamSend::ReceivePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
+	bool RtpStreamSend::ReceivePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
 	{
 		MS_TRACE();
 
@@ -385,7 +385,7 @@ namespace RTC
 		MS_ABORT("invalid method call");
 	}
 
-	void RtpStreamSend::StorePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
+	void RtpStreamSend::StorePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
 	{
 		MS_TRACE();
 
@@ -483,15 +483,15 @@ namespace RTC
 		}
 
 		// Only clone once and only if necessary.
-		if (!*clonedPacket)
+		if (!clonedPacket.get())
 		{
-			*clonedPacket = packet->Clone();
+			clonedPacket = packet->Clone();
 		}
 
 		// Store original packet and some extra info into the retrieved storage item.
-		storageItem->originalPacket = *clonedPacket;
-		storageItem->ssrc           = (*clonedPacket)->GetSsrc();
-		storageItem->sequenceNumber = (*clonedPacket)->GetSequenceNumber();
+		storageItem->originalPacket = clonedPacket;
+		storageItem->ssrc           = clonedPacket->GetSsrc();
+		storageItem->sequenceNumber = clonedPacket->GetSequenceNumber();
 	}
 
 	void RtpStreamSend::ClearBuffer()

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -228,7 +228,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SimpleConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
+	void SimpleConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -640,7 +640,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SimulcastConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
+	void SimulcastConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -532,7 +532,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SvcConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr* clonedPacket)
+	void SvcConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
 	{
 		MS_TRACE();
 

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -95,35 +95,35 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		// Receive all the packets (some of them not in order and/or duplicated).
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet1.get(), &clonedPacket);
+			stream->ReceivePacket(packet1.get(), clonedPacket);
 		}
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet3.get(), &clonedPacket);
+			stream->ReceivePacket(packet3.get(), clonedPacket);
 		}
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet2.get(), &clonedPacket);
+			stream->ReceivePacket(packet2.get(), clonedPacket);
 		}
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet3.get(), &clonedPacket);
+			stream->ReceivePacket(packet3.get(), clonedPacket);
 		}
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet4.get(), &clonedPacket);
+			stream->ReceivePacket(packet4.get(), clonedPacket);
 		}
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet4.get(), &clonedPacket);
+			stream->ReceivePacket(packet4.get(), clonedPacket);
 		}
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet5.get(), &clonedPacket);
+			stream->ReceivePacket(packet5.get(), clonedPacket);
 		}
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet5.get(), &clonedPacket);
+			stream->ReceivePacket(packet5.get(), clonedPacket);
 		}
 
 		// Create a NACK item that request for all the packets.


### PR DESCRIPTION
Make use of Deleter in order to release the memory to the pool after the
last reference release.