### PR TITLE
Fix: create a shared pointer for RTP packet and pass it upwards

### DIFF
--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -138,12 +138,12 @@ namespace RTC
 		{
 			this->externallyManagedBitrate = true;
 		}
-		virtual uint8_t GetBitratePriority() const                                                  = 0;
-		virtual uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss)                         = 0;
-		virtual void ApplyLayers()                                                                  = 0;
-		virtual uint32_t GetDesiredBitrate() const                                                  = 0;
-		virtual void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) = 0;
-		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const                       = 0;
+		virtual uint8_t GetBitratePriority() const                            = 0;
+		virtual uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss)   = 0;
+		virtual void ApplyLayers()                                            = 0;
+		virtual uint32_t GetDesiredBitrate() const                            = 0;
+		virtual void SendRtpPacket(RTC::RtpPacket::SharedPtr& packet)         = 0;
+		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const = 0;
 		virtual RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(
 		  RTC::RtpStreamSend* rtpStream, uint64_t nowMs) = 0;
 		virtual void NeedWorstRemoteFractionLost(uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) = 0;

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -30,7 +30,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket::SharedPtr& packet) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -36,8 +36,9 @@ namespace RTC
 			virtual void OnProducerRtpStreamScore(
 			  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) = 0;
 			virtual void OnProducerRtcpSenderReport(
-			  RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first)                         = 0;
-			virtual void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet) = 0;
+			  RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) = 0;
+			virtual void OnProducerRtpPacketReceived(
+			  RTC::Producer* producer, RTC::RtpPacket::SharedPtr packet)                              = 0;
 			virtual void OnProducerSendRtcpPacket(RTC::Producer* producer, RTC::RTCP::Packet* packet) = 0;
 			virtual void OnProducerNeedWorstRemoteFractionLost(
 			  RTC::Producer* producer, uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) = 0;
@@ -120,7 +121,7 @@ namespace RTC
 		{
 			return std::addressof(this->rtpStreamScores);
 		}
-		ReceiveRtpPacketResult ReceiveRtpPacket(RTC::RtpPacket* packet);
+		ReceiveRtpPacketResult ReceiveRtpPacket(RTC::RtpPacket::SharedPtr packet);
 		void ReceiveRtcpSenderReport(RTC::RTCP::SenderReport* report);
 		void ReceiveRtcpXrDelaySinceLastRr(RTC::RTCP::DelaySinceLastRr::SsrcInfo* ssrcInfo);
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(uint64_t nowMs);

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -61,7 +61,7 @@ namespace RTC
 		void OnTransportProducerRtcpSenderReport(
 		  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) override;
 		void OnTransportProducerRtpPacketReceived(
-		  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpPacket* packet) override;
+		  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpPacket::SharedPtr packet) override;
 		void OnTransportNeedWorstRemoteFractionLost(
 		  RTC::Transport* transport,
 		  RTC::Producer* producer,

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -72,7 +72,7 @@ namespace RTC
 
 		void FillJsonStats(json& jsonObject) override;
 		void SetRtx(uint8_t payloadType, uint32_t ssrc) override;
-		bool ReceivePacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket);
+		bool ReceivePacket(RTC::RtpPacket::SharedPtr& packet);
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket);
 		void ReceiveKeyFrameRequest(RTC::RTCP::FeedbackPs::MessageType messageType);
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
@@ -89,7 +89,7 @@ namespace RTC
 		uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override;
 
 	private:
-		void StorePacket(const RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket);
+		void StorePacket(const RTC::RtpPacket::SharedPtr& packet);
 		void ClearOldPackets(const RtpPacket* packet);
 		void ClearBuffer();
 		void FillRetransmissionContainer(uint16_t seq, uint16_t bitmask);

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -40,7 +40,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket::SharedPtr& packet) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -56,7 +56,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket::SharedPtr& packet) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -51,7 +51,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket) override;
+		void SendRtpPacket(RTC::RtpPacket::SharedPtr& packet) override;
 		RTC::RTCP::CompoundPacket::UniquePtr GetRtcp(RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -94,7 +94,7 @@ namespace RTC
 			virtual void OnTransportProducerRtcpSenderReport(
 			  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) = 0;
 			virtual void OnTransportProducerRtpPacketReceived(
-			  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpPacket* packet) = 0;
+			  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpPacket::SharedPtr packet) = 0;
 			virtual void OnTransportNeedWorstRemoteFractionLost(
 			  RTC::Transport* transport,
 			  RTC::Producer* producer,
@@ -159,7 +159,7 @@ namespace RTC
 		{
 			this->sendTransmission.Update(len, DepLibUV::GetTimeMs());
 		}
-		void ReceiveRtpPacket(RTC::RtpPacket* packet);
+		void ReceiveRtpPacket(RTC::RtpPacket::SharedPtr packet);
 		void ReceiveRtcpPacket(RTC::RTCP::Packet* packet);
 		void ReceiveSctpData(const uint8_t* data, size_t len);
 		void SetNewProducerIdFromInternal(json& internal, std::string& producerId) const;
@@ -208,7 +208,7 @@ namespace RTC
 		  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
 		void OnProducerRtcpSenderReport(
 		  RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) override;
-		void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet) override;
+		void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket::SharedPtr packet) override;
 		void OnProducerSendRtcpPacket(RTC::Producer* producer, RTC::RTCP::Packet* packet) override;
 		void OnProducerNeedWorstRemoteFractionLost(
 		  RTC::Producer* producer, uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) override;

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -112,7 +112,7 @@ namespace RTC
 				}
 
 				// Pass the packet to the parent transport.
-				RTC::Transport::ReceiveRtpPacket(packet.get());
+				RTC::Transport::ReceiveRtpPacket(packet);
 
 				break;
 			}

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -184,7 +184,7 @@ namespace RTC
 		return 0u;
 	}
 
-	void PipeConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
+	void PipeConsumer::SendRtpPacket(RTC::RtpPacket::SharedPtr& packet)
 	{
 		MS_TRACE();
 
@@ -253,13 +253,13 @@ namespace RTC
 		}
 
 		// Process the packet.
-		if (rtpStream->ReceivePacket(packet, clonedPacket))
+		if (rtpStream->ReceivePacket(packet))
 		{
 			// Send the packet.
-			this->listener->OnConsumerSendRtpPacket(this, packet);
+			this->listener->OnConsumerSendRtpPacket(this, packet.get());
 
 			// May emit 'trace' event.
-			EmitTraceEventRtpAndKeyFrameTypes(packet);
+			EmitTraceEventRtpAndKeyFrameTypes(packet.get());
 		}
 		else
 		{

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -634,7 +634,7 @@ namespace RTC
 		}
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet.get());
+		RTC::Transport::ReceiveRtpPacket(packet);
 	}
 
 	inline void PipeTransport::OnRtcpDataReceived(

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -862,7 +862,7 @@ namespace RTC
 		}
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet.get());
+		RTC::Transport::ReceiveRtpPacket(packet);
 	}
 
 	inline void PlainTransport::OnRtcpDataReceived(

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -689,7 +689,7 @@ namespace RTC
 	}
 
 	inline void Router::OnTransportProducerRtpPacketReceived(
-	  RTC::Transport* /*transport*/, RTC::Producer* producer, RTC::RtpPacket* packet)
+	  RTC::Transport* /*transport*/, RTC::Producer* producer, RTC::RtpPacket::SharedPtr packet)
 	{
 		MS_TRACE();
 
@@ -697,11 +697,6 @@ namespace RTC
 
 		if (!consumers.empty())
 		{
-			// Cloned ref-counted packet that consumers will all store for as long as needed
-			// while also avoiding multiple allocations unless absolutely necessary.
-			// Clone only happens if needed though.
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-
 			for (auto* consumer : consumers)
 			{
 				// Update MID RTP extension value.
@@ -710,7 +705,7 @@ namespace RTC
 				if (!mid.empty())
 					packet->UpdateMid(mid);
 
-				consumer->SendRtpPacket(packet, clonedPacket);
+				consumer->SendRtpPacket(packet);
 			}
 		}
 
@@ -722,7 +717,7 @@ namespace RTC
 
 			for (auto* rtpObserver : rtpObservers)
 			{
-				rtpObserver->ReceiveRtpPacket(producer, packet);
+				rtpObserver->ReceiveRtpPacket(producer, packet.get());
 			}
 		}
 	}

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -228,7 +228,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SimpleConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
+	void SimpleConsumer::SendRtpPacket(RTC::RtpPacket::SharedPtr& packet)
 	{
 		MS_TRACE();
 
@@ -291,13 +291,13 @@ namespace RTC
 		}
 
 		// Process the packet.
-		if (this->rtpStream->ReceivePacket(packet, clonedPacket))
+		if (this->rtpStream->ReceivePacket(packet))
 		{
 			// Send the packet.
-			this->listener->OnConsumerSendRtpPacket(this, packet);
+			this->listener->OnConsumerSendRtpPacket(this, packet.get());
 
 			// May emit 'trace' event.
-			EmitTraceEventRtpAndKeyFrameTypes(packet);
+			EmitTraceEventRtpAndKeyFrameTypes(packet.get());
 		}
 		else
 		{

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -640,7 +640,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SimulcastConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
+	void SimulcastConsumer::SendRtpPacket(RTC::RtpPacket::SharedPtr& packet)
 	{
 		MS_TRACE();
 
@@ -890,16 +890,16 @@ namespace RTC
 		}
 
 		// Process the packet.
-		if (this->rtpStream->ReceivePacket(packet, clonedPacket))
+		if (this->rtpStream->ReceivePacket(packet))
 		{
 			if (this->rtpSeqManager.GetMaxOutput() == packet->GetSequenceNumber())
 				this->lastSentPacketHasMarker = packet->HasMarker();
 
 			// Send the packet.
-			this->listener->OnConsumerSendRtpPacket(this, packet);
+			this->listener->OnConsumerSendRtpPacket(this, packet.get());
 
 			// May emit 'trace' event.
-			EmitTraceEventRtpAndKeyFrameTypes(packet);
+			EmitTraceEventRtpAndKeyFrameTypes(packet.get());
 		}
 		else
 		{

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -532,7 +532,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SvcConsumer::SendRtpPacket(RTC::RtpPacket* packet, RTC::RtpPacket::SharedPtr& clonedPacket)
+	void SvcConsumer::SendRtpPacket(RTC::RtpPacket::SharedPtr& packet)
 	{
 		MS_TRACE();
 
@@ -625,13 +625,13 @@ namespace RTC
 		}
 
 		// Process the packet.
-		if (this->rtpStream->ReceivePacket(packet, clonedPacket))
+		if (this->rtpStream->ReceivePacket(packet))
 		{
 			// Send the packet.
-			this->listener->OnConsumerSendRtpPacket(this, packet);
+			this->listener->OnConsumerSendRtpPacket(this, packet.get());
 
 			// May emit 'trace' event.
-			EmitTraceEventRtpAndKeyFrameTypes(packet);
+			EmitTraceEventRtpAndKeyFrameTypes(packet.get());
 		}
 		else
 		{

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1674,7 +1674,7 @@ namespace RTC
 #endif
 	}
 
-	void Transport::ReceiveRtpPacket(RTC::RtpPacket* packet)
+	void Transport::ReceiveRtpPacket(RTC::RtpPacket::SharedPtr packet)
 	{
 		MS_TRACE();
 
@@ -1689,10 +1689,10 @@ namespace RTC
 
 		// Feed the TransportCongestionControlServer.
 		if (this->tccServer)
-			this->tccServer->IncomingPacket(nowMs, packet);
+			this->tccServer->IncomingPacket(nowMs, packet.get());
 
 		// Get the associated Producer.
-		RTC::Producer* producer = this->rtpListener.GetProducer(packet);
+		RTC::Producer* producer = this->rtpListener.GetProducer(packet.get());
 
 		if (!producer)
 		{
@@ -1720,10 +1720,10 @@ namespace RTC
 		switch (result)
 		{
 			case RTC::Producer::ReceiveRtpPacketResult::MEDIA:
-				this->recvRtpTransmission.Update(packet);
+				this->recvRtpTransmission.Update(packet.get());
 				break;
 			case RTC::Producer::ReceiveRtpPacketResult::RETRANSMISSION:
-				this->recvRtxTransmission.Update(packet);
+				this->recvRtxTransmission.Update(packet.get());
 				break;
 			case RTC::Producer::ReceiveRtpPacketResult::DISCARDED:
 				// Tell the child class to remove this SSRC.
@@ -2553,7 +2553,8 @@ namespace RTC
 		this->listener->OnTransportProducerRtcpSenderReport(this, producer, rtpStream, first);
 	}
 
-	inline void Transport::OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet)
+	inline void Transport::OnProducerRtpPacketReceived(
+	  RTC::Producer* producer, RTC::RtpPacket::SharedPtr packet)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -1025,7 +1025,7 @@ namespace RTC
 		this->iceServer->ForceSelectedTuple(tuple);
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet.get());
+		RTC::Transport::ReceiveRtpPacket(packet);
 	}
 
 	inline void WebRtcTransport::OnRtcpDataReceived(

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -93,38 +93,13 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		RtpStreamSend* stream = new RtpStreamSend(&testRtpStreamListener, params, mid, true);
 
 		// Receive all the packets (some of them not in order and/or duplicated).
-		{
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet1.get(), clonedPacket);
-		}
-		{
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet3.get(), clonedPacket);
-		}
-		{
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet2.get(), clonedPacket);
-		}
-		{
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet3.get(), clonedPacket);
-		}
-		{
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet4.get(), clonedPacket);
-		}
-		{
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet4.get(), clonedPacket);
-		}
-		{
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet5.get(), clonedPacket);
-		}
-		{
-			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet5.get(), clonedPacket);
-		}
+		stream->ReceivePacket(packet1);
+		stream->ReceivePacket(packet3);
+		stream->ReceivePacket(packet2);
+		stream->ReceivePacket(packet3);
+		stream->ReceivePacket(packet4);
+		stream->ReceivePacket(packet4);
+		stream->ReceivePacket(packet5);
 
 		// Create a NACK item that request for all the packets.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params.ssrc);
@@ -161,72 +136,6 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		REQUIRE(rtxPacket4);
 		REQUIRE(rtxPacket4->GetSequenceNumber() == packet5->GetSequenceNumber());
 		REQUIRE(rtxPacket4->GetTimestamp() == packet5->GetTimestamp());
-
-		delete stream;
-	}
-
-	SECTION("Cloned RTP packet differs from original, get retransmitted packets")
-	{
-		// clang-format off
-		uint8_t rtpBuffer1[] =
-		{
-			0b10000000, 0b01111011, 0b01010010, 0b00001110,
-			0b01011011, 0b01101011, 0b11001010, 0b10110101,
-			0, 0, 0, 2
-		};
-		// clang-format on
-
-		RtpStream::Params params;
-
-		params.ssrc      = 1111;
-		params.clockRate = 90000;
-		params.useNack   = true;
-
-		// Create a RtpStreamSend.
-		std::string mid{ "" };
-		RtpStreamSend* stream = new RtpStreamSend(&testRtpStreamListener, params, mid, true);
-
-		auto packet = RtpPacket::Parse(rtpBuffer1, sizeof(rtpBuffer1));
-
-		REQUIRE(packet);
-
-		// Original packet.
-		packet->SetSsrc(1111);
-		packet->SetSequenceNumber(2222);
-		packet->SetTimestamp(3333);
-
-		auto clonedPacket = packet->Clone();
-
-		REQUIRE(clonedPacket);
-
-		// Cloned packet.
-		clonedPacket->SetSsrc(4444);
-		clonedPacket->SetSequenceNumber(5555);
-		clonedPacket->SetTimestamp(6666);
-
-		stream->ReceivePacket(packet.get(), clonedPacket);
-
-		// Create a NACK item that requests the packet.
-		RTCP::FeedbackRtpNackPacket nackPacket(0, params.ssrc);
-		auto* nackItem = new RTCP::FeedbackRtpNackItem(packet->GetSequenceNumber(), 0b0000000000000000);
-
-		nackPacket.AddItem(nackItem);
-
-		REQUIRE(nackItem->GetPacketId() == packet->GetSequenceNumber());
-		REQUIRE(nackItem->GetLostPacketBitmask() == 0b0000000000000000);
-
-		stream->ReceiveNack(&nackPacket);
-
-		REQUIRE(testRtpStreamListener.retransmittedPackets.size() == 1);
-
-		auto rtxPacket = testRtpStreamListener.retransmittedPackets[0];
-
-		testRtpStreamListener.retransmittedPackets.clear();
-
-		// Make sure RTX packets correspond match the origina packet info.
-		REQUIRE(rtxPacket);
-		REQUIRE(rtxPacket->GetSequenceNumber() == 2222);
-		REQUIRE(rtxPacket->GetTimestamp() == 3333);
 
 		delete stream;
 	}


### PR DESCRIPTION
Fixes a bug present in XXXTransport.cpp here: https://github.com/nazar-pc/mediasoup/blob/memory-optimizations/worker/src/RTC/WebRtcTransport.cpp#L1028

A `shared_ptr` is being created in that scope and passing the owned `RtpPacket` pointer upwards. When that `shared_ptr` in XXXTransport.cpp goes out of scope it will decrement the ref-counter, destruct the `RtpPacket` instance and return the buffer to the pool while we are still using all around the pointer that is already invalidated but present in the object pool.

Inmplicit bonus: avoids cloning every original RTP packet for retransmissions. The original packet which is contained in a `shared_ptr` since it's parsed is used instead.