### PR TITLE
Fix shared pointer usage

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/modules/pacing/paced_sender.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/pacing/paced_sender.cc
@@ -190,7 +190,7 @@ void PacedSender::Process() {
 
   size_t bytes_sent = 0;
   // MS_NOTE: Let's not use a useless vector.
-  RTC::RtpPacket::SharedPtr padding_packet{ nullptr };
+  RTC::RtpPacket* padding_packet{ nullptr };
 
   // Check if we should send padding.
   while (true)
@@ -212,7 +212,7 @@ void PacedSender::Process() {
     // TODO: REMOVE.
     // MS_DEBUG_DEV("sending padding packet [size:%zu]", padding_packet->GetSize());
 
-    packet_router_->SendPacket(padding_packet.get(), pacing_info);
+    packet_router_->SendPacket(padding_packet, pacing_info);
     bytes_sent += padding_packet->GetSize();
 
     if (recommended_probe_size && bytes_sent > *recommended_probe_size)

--- a/worker/deps/libwebrtc/libwebrtc/modules/pacing/packet_router.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/pacing/packet_router.h
@@ -35,7 +35,7 @@ class PacketRouter {
                           const PacedPacketInfo& cluster_info) = 0;
 
   // MS_NOTE: Changed to return a single RtpPacket pointer (maybe nullptr).
-  virtual RTC::RtpPacket::SharedPtr GeneratePadding(size_t target_size_bytes) = 0;
+  virtual RTC::RtpPacket* GeneratePadding(size_t target_size_bytes) = 0;
 };
 }  // namespace webrtc
 #endif  // MODULES_PACING_PACKET_ROUTER_H_

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -133,7 +133,7 @@ namespace RTC
 			// clang-format on
 		}
 
-		static SharedPtr Parse(const uint8_t* data, size_t len);
+		static RtpPacket* Parse(const uint8_t* data, size_t len);
 
 	private:
 		RtpPacket(
@@ -144,9 +144,9 @@ namespace RTC
 		  uint8_t payloadPadding,
 		  size_t size);
 
+	public:
 		~RtpPacket();
 
-	public:
 		void Dump() const;
 
 		void FillJson(json& jsonObject) const;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -144,8 +144,14 @@ namespace RTC
 		  uint8_t payloadPadding,
 		  size_t size);
 
-	public:
 		~RtpPacket();
+
+	public:
+		// RtpPackets created with Parse() need to manually call this method
+		// in order to return the instance memory to the pool.
+		// RtpPackets created with Clone() don't, since the shared_ptr allocator
+		// will automatically do it.
+		void ReturnToPool();
 
 		void Dump() const;
 

--- a/worker/include/RTC/RtpProbationGenerator.hpp
+++ b/worker/include/RTC/RtpProbationGenerator.hpp
@@ -13,6 +13,16 @@ namespace RTC
 
 	class RtpProbationGenerator
 	{
+		// Custom deleter for RtpPacket unique_ptr.
+		struct Deleter
+		{
+			// Called by unique_ptr to destroy/free the Packet.
+			void operator()(RTC::RtpPacket* packet)
+			{
+				packet->ReturnToPool();
+			}
+		};
+
 	public:
 		explicit RtpProbationGenerator();
 		virtual ~RtpProbationGenerator();
@@ -23,7 +33,7 @@ namespace RTC
 	private:
 		// Allocated by this.
 		uint8_t* probationPacketBuffer{ nullptr };
-		std::unique_ptr<RTC::RtpPacket> probationPacket{ nullptr };
+		std::unique_ptr<RTC::RtpPacket, Deleter> probationPacket{ nullptr };
 	}; // namespace RTC
 
 } // namespace RTC

--- a/worker/include/RTC/RtpProbationGenerator.hpp
+++ b/worker/include/RTC/RtpProbationGenerator.hpp
@@ -18,12 +18,12 @@ namespace RTC
 		virtual ~RtpProbationGenerator();
 
 	public:
-		RTC::RtpPacket::SharedPtr GetNextPacket(size_t size);
+		RTC::RtpPacket* GetNextPacket(size_t size);
 
 	private:
 		// Allocated by this.
 		uint8_t* probationPacketBuffer{ nullptr };
-		RTC::RtpPacket::SharedPtr probationPacket{ nullptr };
+		std::unique_ptr<RTC::RtpPacket> probationPacket{ nullptr };
 	}; // namespace RTC
 
 } // namespace RTC

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -98,7 +98,7 @@ namespace RTC
 		/* Pure virtual methods inherited from webrtc::PacketRouter. */
 	public:
 		void SendPacket(RTC::RtpPacket* packet, const webrtc::PacedPacketInfo& pacingInfo) override;
-		RTC::RtpPacket::SharedPtr GeneratePadding(size_t size) override;
+		RTC::RtpPacket* GeneratePadding(size_t size) override;
 
 		/* Pure virtual methods inherited from RTC::Timer. */
 	public:

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -112,7 +112,7 @@ namespace RTC
 				}
 
 				// Pass the packet to the parent transport.
-				RTC::Transport::ReceiveRtpPacket(packet.get());
+				RTC::Transport::ReceiveRtpPacket(packet);
 
 				break;
 			}

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -634,7 +634,7 @@ namespace RTC
 		}
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet.get());
+		RTC::Transport::ReceiveRtpPacket(packet);
 	}
 
 	inline void PipeTransport::OnRtcpDataReceived(

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -862,7 +862,7 @@ namespace RTC
 		}
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet.get());
+		RTC::Transport::ReceiveRtpPacket(packet);
 	}
 
 	inline void PlainTransport::OnRtcpDataReceived(

--- a/worker/src/RTC/RtpProbationGenerator.cpp
+++ b/worker/src/RTC/RtpProbationGenerator.cpp
@@ -48,8 +48,8 @@ namespace RTC
 		std::memcpy(this->probationPacketBuffer, ProbationPacketHeader, ProbationPacketHeaderSize);
 
 		// Create the probation RTP packet.
-		this->probationPacket =
-		  RTC::RtpPacket::Parse(this->probationPacketBuffer, MaxProbationPacketSize);
+		this->probationPacket.reset(
+		  RTC::RtpPacket::Parse(this->probationPacketBuffer, MaxProbationPacketSize));
 
 		// Sex fixed codec payload type.
 		this->probationPacket->SetPayloadType(RTC::RtpProbationCodecPayloadType);
@@ -128,12 +128,9 @@ namespace RTC
 
 		// Delete the probation packet buffer.
 		delete[] this->probationPacketBuffer;
-
-		// Release the probation RTP packet.
-		this->probationPacket.reset();
 	}
 
-	RTC::RtpPacket::SharedPtr RtpProbationGenerator::GetNextPacket(size_t size)
+	RTC::RtpPacket* RtpProbationGenerator::GetNextPacket(size_t size)
 	{
 		MS_TRACE();
 
@@ -157,6 +154,6 @@ namespace RTC
 		// Set probation packet payload size.
 		this->probationPacket->SetPayloadLength(size - ProbationPacketHeaderSize);
 
-		return this->probationPacket;
+		return this->probationPacket.get();
 	}
 } // namespace RTC

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1705,6 +1705,8 @@ namespace RTC
 			// Tell the child class to remove this SSRC.
 			RecvStreamClosed(packet->GetSsrc());
 
+			delete packet;
+
 			return;
 		}
 
@@ -1731,6 +1733,8 @@ namespace RTC
 				break;
 			default:;
 		}
+
+		delete packet;
 	}
 
 	void Transport::ReceiveRtcpPacket(RTC::RTCP::Packet* packet)

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1705,7 +1705,7 @@ namespace RTC
 			// Tell the child class to remove this SSRC.
 			RecvStreamClosed(packet->GetSsrc());
 
-			delete packet;
+			packet->ReturnToPool();
 
 			return;
 		}
@@ -1734,7 +1734,7 @@ namespace RTC
 			default:;
 		}
 
-		delete packet;
+		packet->ReturnToPool();
 	}
 
 	void Transport::ReceiveRtcpPacket(RTC::RTCP::Packet* packet)

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -493,7 +493,7 @@ namespace RTC
 		this->listener->OnTransportCongestionControlClientSendRtpPacket(this, packet, pacingInfo);
 	}
 
-	RTC::RtpPacket::SharedPtr TransportCongestionControlClient::GeneratePadding(size_t size)
+	RTC::RtpPacket* TransportCongestionControlClient::GeneratePadding(size_t size)
 	{
 		MS_TRACE();
 		MS_ASSERT(this->probationGenerator, "probation generator not initialized")

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -1025,7 +1025,7 @@ namespace RTC
 		this->iceServer->ForceSelectedTuple(tuple);
 
 		// Pass the packet to the parent transport.
-		RTC::Transport::ReceiveRtpPacket(packet.get());
+		RTC::Transport::ReceiveRtpPacket(packet);
 	}
 
 	inline void WebRtcTransport::OnRtcpDataReceived(

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -131,7 +131,7 @@ void validate(std::vector<TestNackGeneratorInput>& inputs)
 
 		packet->SetPayloadDescriptorHandler(tpdh);
 		packet->SetSequenceNumber(input.seq);
-		nackGenerator.ReceivePacket(packet.get(), /*isRecovered*/ false);
+		nackGenerator.ReceivePacket(packet, /*isRecovered*/ false);
 
 		listener.Check(nackGenerator);
 	}

--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -143,25 +143,25 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		RtpStreamRecv rtpStream(&listener, params);
 
 		packet->SetSequenceNumber(1);
-		rtpStream.ReceivePacket(packet.get());
+		rtpStream.ReceivePacket(packet);
 
 		packet->SetSequenceNumber(3);
 		listener.shouldTriggerNack = true;
 		listener.shouldTriggerPLI  = false;
 		listener.shouldTriggerFIR  = false;
-		rtpStream.ReceivePacket(packet.get());
+		rtpStream.ReceivePacket(packet);
 
 		REQUIRE(listener.nackedSeqNumbers.size() == 1);
 		REQUIRE(listener.nackedSeqNumbers[0] == 2);
 		listener.nackedSeqNumbers.clear();
 
 		packet->SetSequenceNumber(2);
-		rtpStream.ReceivePacket(packet.get());
+		rtpStream.ReceivePacket(packet);
 
 		REQUIRE(listener.nackedSeqNumbers.size() == 0);
 
 		packet->SetSequenceNumber(4);
-		rtpStream.ReceivePacket(packet.get());
+		rtpStream.ReceivePacket(packet);
 
 		REQUIRE(listener.nackedSeqNumbers.size() == 0);
 	}
@@ -172,13 +172,13 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		RtpStreamRecv rtpStream(&listener, params);
 
 		packet->SetSequenceNumber(0xfffe);
-		rtpStream.ReceivePacket(packet.get());
+		rtpStream.ReceivePacket(packet);
 
 		packet->SetSequenceNumber(1);
 		listener.shouldTriggerNack = true;
 		listener.shouldTriggerPLI  = false;
 		listener.shouldTriggerFIR  = false;
-		rtpStream.ReceivePacket(packet.get());
+		rtpStream.ReceivePacket(packet);
 
 		REQUIRE(listener.nackedSeqNumbers.size() == 2);
 		REQUIRE(listener.nackedSeqNumbers[0] == 0xffff);
@@ -192,14 +192,14 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		RtpStreamRecv rtpStream(&listener, params);
 
 		packet->SetSequenceNumber(1);
-		rtpStream.ReceivePacket(packet.get());
+		rtpStream.ReceivePacket(packet);
 
 		// Seq different is bigger than MaxNackPackets in NackGenerator, so it
 		// triggers a key frame.
 		packet->SetSequenceNumber(1003);
 		listener.shouldTriggerPLI = true;
 		listener.shouldTriggerFIR = false;
-		rtpStream.ReceivePacket(packet.get());
+		rtpStream.ReceivePacket(packet);
 	}
 
 	// Must run the loop to wait for UV timers and close them.

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -95,7 +95,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		// Receive all the packets (some of them not in order and/or duplicated).
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
-			stream->ReceivePacket(packet1.get(), clonedPacket);
+			stream->ReceivePacket(packet1, clonedPacket);
 		}
 		{
 			RtpPacket::SharedPtr clonedPacket{ nullptr };
@@ -204,7 +204,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		clonedPacket->SetSequenceNumber(5555);
 		clonedPacket->SetTimestamp(6666);
 
-		stream->ReceivePacket(packet.get(), clonedPacket);
+		stream->ReceivePacket(packet, clonedPacket);
 
 		// Create a NACK item that requests the packet.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params.ssrc);


### PR DESCRIPTION
* A shared pointer was being wrongly used in XXXTransport.cpp.
* Do only use shared pointer in RtpPacket::Clone(), since it's the only
  case where it needs to be shared among RtpStreamSend instances.